### PR TITLE
Improve compatibility with registry subkeys

### DIFF
--- a/WinSCPService.cs
+++ b/WinSCPService.cs
@@ -144,16 +144,21 @@ namespace Flow.Launcher.Plugin.WinSCP
                         "7" => "s3",
                         _ => "sftp"
                     };
-                    _entries.Add(
-                        new()
-                        {
-                            Identifier = subKey,
-                            Title = HttpUtility.UrlDecode(subKey),
-                            Protocol = protocol,
-                            Username = SessionSubKey.GetValue("UserName").ToString(),
-                            Hostname = SessionSubKey.GetValue("HostName").ToString(),
-                        }
-                    );
+                    SessionEntry entry = new()
+                    {
+                        Identifier = subKey,
+                        Title = HttpUtility.UrlDecode(subKey),
+                        Hostname = SessionSubKey.GetValue("HostName").ToString(),
+                        Protocol = protocol,
+                    };
+
+                    Object username = SessionSubKey.GetValue("UserName");
+                    if (username != null)
+                    {
+                        entry.Username = username.ToString();
+                    }
+
+                    _entries.Add(entry);
                 }
                 catch (Exception)
                 {

--- a/WinSCPService.cs
+++ b/WinSCPService.cs
@@ -138,19 +138,24 @@ namespace Flow.Launcher.Plugin.WinSCP
 
                 try
                 {
-                    string protocol = SessionSubKey.GetValue("FSProtocol").ToString() switch
-                    {
-                        "0" => "scp",
-                        "7" => "s3",
-                        _ => "sftp"
-                    };
                     SessionEntry entry = new()
                     {
                         Identifier = subKey,
                         Title = HttpUtility.UrlDecode(subKey),
                         Hostname = SessionSubKey.GetValue("HostName").ToString(),
-                        Protocol = protocol,
+                        Protocol = "sftp",
                     };
+
+                    Object protocol = SessionSubKey.GetValue("FSProtocol");
+                    if(protocol != null)
+                    {
+                        entry.Protocol = protocol.ToString() switch
+                        {
+                            "0" => "scp",
+                            "7" => "s3",
+                            _ => "sftp"
+                        };
+                    }
 
                     Object username = SessionSubKey.GetValue("UserName");
                     if (username != null)


### PR DESCRIPTION
WinSCP doesn't always create some of the subkeys in the registry.

SFTP connections should now work, even if the protocol wasn't explicitly set.
You should also be able to load sessions without a set username.
